### PR TITLE
Fixing broken `pip install` by enforcing PEP-440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ with io.open(path.join(THIS_DIRECTORY, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='andaluh',
-    version='0.2.1',
+    version='0.2.2',
     description='Transliterate español (spanish) spelling to andaluz proposals',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     project_urls={
         "Source Code": "https://github.com/andalugeeks/andaluh-py"
     },
-    python_requires=">=3.5.*",
+    python_requires=">=3.5",
     platforms=['win32', 'linux2'],
     license='GNU LESSER GENERAL PUBLIC LICENSE',
     classifiers=[


### PR DESCRIPTION
According to [PEP-440](https://peps.python.org/pep-0440/#compatible-release), using `>=` operator is only possible for `>= V.N` cases and not `>= V.N.*`. Since version `24.1` ([changelog](https://pip.pypa.io/en/stable/news/#b1-2024-05-06)) pip enforces PEP-440 rules and simply doesn't let one install this library due to the error below.

So, this little PR simply fixes the error by enforcing PEP-440.

```bash
$ pip install andaluh
Defaulting to user installation because normal site-packages is not writeable
Collecting andaluh
  Using cached andaluh-0.2.1.tar.gz (12 kB)
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [1 lines of output]
      error in andaluh setup command: 'python_requires' must be a string containing valid version specifiers; Invalid specifier: '>=3.5.*'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```  