### PR TITLE
fix(bin/andaluh): replace python shebang by python3

### DIFF
--- a/bin/andaluh
+++ b/bin/andaluh
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 # vim: ts=4
 ###


### PR DESCRIPTION
Replaces shebang. `#!/usr/bin/env python` is too much generic. 
New shebang is `#!/usr/bin/env python3`