### PR TITLE
fix(pyproject.toml): adds commitizen configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,3 +99,13 @@ deps =
 commands = 
     flake8 andaluh/ bin/
 """ 
+
+# Configuración de commitizen
+[tool.commitizen]
+name = "cz_conventional_commits"
+version = "0.3.1"
+version_files = [
+    "pyproject.toml:version"
+]
+tag_format = "v$version"
+update_changelog_on_bump = true 


### PR DESCRIPTION
This pull request introduces a configuration for `commitizen` in the `pyproject.toml` file to standardize commit messages and automate versioning.

Key change:

* Added a `[tool.commitizen]` section in `pyproject.toml` to configure `commitizen` with the `cz_conventional_commits` name, version tracking, tag format, and automatic changelog updates.